### PR TITLE
Handling systems without Python requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ subsonic addon for xbmc
 1. `curl -L https://github.com/xsteadfastx/subsonic-xbmc-addon/archive/master.zip -o subsonic.zip`
 2. `cp -Rv subsonic-xbmc-addon/plugin.audio.subsonic ~/.xbmc/addons/`
 3. Configure your url, username and password
+4. Put the contents of the [script.module.requests](https://github.com/beenje/script.module.requests) library in .kodi/addons/script.module.requests
 
 ## Workarounds
 There is a problem that xbmc doesnt play the next song in queue. a workaround is to put the playercorefactory file in the userdata folder. this switches the default player to "dvdplayer" for subsonic. you do that with:

--- a/plugin.audio.subsonic/addon.py
+++ b/plugin.audio.subsonic/addon.py
@@ -7,7 +7,7 @@ import requests
 
 
 def build_url(query):
-    return base_url + '?' + urllib.urlencode(query)
+    return base_url + '?' + urllib.urlencode(dict([k.encode('utf-8'),unicode(v).encode('utf-8')] for k,v in query.items()))
 
 
 class Subsonic(object):

--- a/plugin.audio.subsonic/addon.xml
+++ b/plugin.audio.subsonic/addon.xml
@@ -2,6 +2,7 @@
 <addon id="plugin.audio.subsonic" name="Subsonic" version="0.0.1" provider-name="xsteadfastx">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>
+    <import addon="script.module.requests" version="2.7.0" />
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>audio</provides>


### PR DESCRIPTION
OpenElec systems as well as others can't easily install [Python requests](https://github.com/kennethreitz/requests) via command line due to a lack of distutils and proper package management.

This pull modifies the install instructions to note that, as well as a couple minor updates in addon.py and addon.xml
